### PR TITLE
zealot-data volume 拆分处理

### DIFF
--- a/config.env
+++ b/config.env
@@ -1,5 +1,5 @@
 ######################################
-# 服务器
+# 域名及证书
 ######################################
 
 # 域名，比如 zealot.com，无需加 http:// 或 https:// 前缀
@@ -11,26 +11,6 @@
 # 自签名证书文件名（和 Let's Encrypt 注册电子邮箱名二选一，不能同时设置）
 # ZEALOT_CERT=
 # ZEALOT_CERT_KEY=
-
-# 如果使用 Nginx、Caddy、Apache 反向代理 Zealot 建议关闭
-# RAILS_SERVE_STATIC_FILES=true
-
-######################################
-# 发送邮件
-######################################
-
-# SMTP
-SMTP_ADDRESS=smtp.gmail.com
-SMTP_PORT=587
-SMTP_DOMAIN=gmail.com
-SMTP_USERNAME=you@gmail.com
-SMTP_PASSWORD=yourpassword
-SMTP_AUTH_METHOD=plain
-SMTP_ENABLE_STARTTLS_AUTO=true
-
-# 邮件默认收发人
-ACTION_MAILER_DEFAULT_FROM=you@gmail.com
-ACTION_MAILER_DEFAULT_TO=you@gmail.com
 
 ######################################
 # 账户
@@ -78,6 +58,23 @@ LDAP_BASE="ou=People,dc=example,dc=com"
 LDAP_UID=uid
 
 ######################################
+# 发送邮件
+######################################
+
+# SMTP
+SMTP_ADDRESS=smtp.gmail.com
+SMTP_PORT=587
+SMTP_DOMAIN=gmail.com
+SMTP_USERNAME=you@gmail.com
+SMTP_PASSWORD=yourpassword
+SMTP_AUTH_METHOD=plain
+SMTP_ENABLE_STARTTLS_AUTO=true
+
+# 邮件默认收发人
+ACTION_MAILER_DEFAULT_FROM=notifiacation@zealot.com
+ACTION_MAILER_DEFAULT_TO=no-reply@zealot.com
+
+######################################
 # 定时任务
 ######################################
 
@@ -91,12 +88,6 @@ LDAP_UID=uid
 
 # 匿名错误上报
 ZEALOT_SENTRY_DISABLE=false
-
-# Google Analytics 统计（尚未实现，哈哈哈）
-# ZEALOT_GOOGLE_ANALYTICS_UA='xxx'
-
-
-
 
 ######################################
 # 开发使用变量 （非开发者请忽略下面）

--- a/templates/docker-compose/base.yml
+++ b/templates/docker-compose/base.yml
@@ -11,10 +11,11 @@ x-defaults: &defaults
     ZEALOT_REDIS_HOST: redis
     ZEALOT_POSTGRES_HOST: postgres
   volumes:
-    - zealot-data:/app/public
+    - zealot-uploads:/app/public/uploads
+    - zealot-backup:/app/public/backup
     - ./log:/app/log
   healthcheck:
-    test: ["CMD-SHELL", "wget -q --spider --proxy=off localhost:3000/health || exit 1"]
+    test: ["CMD-SHELL", "wget -q --spider --proxy=off localhost/health || exit 1"]
   logging:
     driver: "json-file"
     options:

--- a/templates/docker-compose/external-volumes.yml
+++ b/templates/docker-compose/external-volumes.yml
@@ -1,6 +1,8 @@
 
 volumes:
-  zealot-data:
+  zealot-uploads:
+    external: true
+  zealot-backup:
     external: true
   zealot-redis:
     external: true

--- a/templates/docker-compose/local-volumes.yml
+++ b/templates/docker-compose/local-volumes.yml
@@ -1,11 +1,17 @@
 
 volumes:
-  zealot-data:
+  zealot-uploads:
     driver: local
     driver_opts:
       o: bind
       type: none
-      device: /tmp/zealot
+      device: /tmp/zealot/uploads
+  zealot-backup:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: /tmp/zealot/backup
   zealot-redis:
     driver: local
     driver_opts:


### PR DESCRIPTION
原因具体看 tryzealot/zealot#540

## 变更内容

原有 `zealot-data` 不再使用拆分为 `zealot-uploads` 和 `zealot-backup`

## 迁移工作

新部署的不受影响，对于已部署的项目，需要从 docker-compose.yml 修改对应的配置，具体看 [外部 volumes](https://github.com/tryzealot/zealot-docker/pull/9/files#diff-3c891c10eb4576162f73148bc76a72d4f07142622807ac6772682fc11a418cd7L3) 或者 [本地路径 voluems](https://github.com/tryzealot/zealot-docker/pull/9/files#diff-1fa08ac858f998919209e1ba673b5110d0add74d2da4ed60bbea1092b8ec7ef4L3) 部分

### 外部 volumes

```bash
docker run --rm \
  -v zealot-data:/data \
  -v zealot-backup:/bakcup \
  -v zealot-uploads:/uploads \
  alpine ash -c "cp -r /data/uploads/ / && cp -r /data/backup /"
```

### 本地路径 volumes

```diff
-  zealot-data:
-    driver: local
-    driver_opts:
-      o: bind
-      type: none
-      device: /tmp/zealot/data
+  zealot-uploads:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: /tmp/zealot/data/uploads
+  zealot-backup:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: /tmp/zealot/data/backup

```