### PR TITLE
Configuration environment variable additions and fixes

### DIFF
--- a/config.env
+++ b/config.env
@@ -18,6 +18,13 @@
 # ZEALOT_CERT=
 # ZEALOT_CERT_KEY=
 
+# Force SSL setting and do not ask when running ./deploy
+# Can be one of "letsencrypt", "self-signed", or "false"
+# ZEALOT_FORCE_SSL=false
+
+# Port to use if SSL is disabled
+# ZEALOT_NO_SSL_PORT=80
+
 ######################################
 # 账户
 ######################################

--- a/deploy
+++ b/deploy
@@ -10,6 +10,9 @@
 
 set -eE
 
+if [ -e "./env.sh" ]; then
+  source "./env.sh"
+fi
 source "$(dirname $0)/scripts/function.sh"
 
 source "scripts/load-cli-parser.sh"

--- a/env.sample.sh
+++ b/env.sample.sh
@@ -1,0 +1,11 @@
+# Sample env.sh. Rename to env.sh to use
+# These setting bypass user input and hard set the values into .env upon running ./deploy
+
+# Set SSL to "false", "letsencrypt", or "self-signed"
+# export ZEALOT_FORCE_SSL=false
+
+# Set the external port for zealot to run on if not using SSL
+# export ZEALOT_NO_SSL_PORT=8008
+
+# Set the location of the zealot data to either "docker" or "local"
+# export ZEALOT_FORCE_VOLUME=docker

--- a/scripts/configure-cert.sh
+++ b/scripts/configure-cert.sh
@@ -92,6 +92,28 @@ check_or_generate_selfsigned_ssl () {
 ## Start deploy flow
 ##
 choose_deploy () {
+  set +u
+  echo "ZEALOT_FORCE_SSL=${ZEALOT_FORCE_SSL}"
+  if [ -n $ZEALOT_FORCE_SSL ]; then
+    case "$ZEALOT_FORCE_SSL" in
+      "letsencrypt" )
+        check_or_configure_letsencrypt_ssl;;
+      "self-signed" )
+        check_or_generate_selfsigned_ssl;;
+      "false" )
+        SSL_NAME=false
+        ;;
+      * )
+        echo "Invalid ZEALOT_FORCE_SSL value, Quitting"
+        exit
+        ;;
+    esac
+    echo "${_endgroup}"
+    set -u
+    return
+  fi
+  set -u
+
   printf "How do you deploy?\n\
   Use [L]et's Encryt SSL (default)\n\
   Use [S]elf-signed SSL\n\

--- a/scripts/configure-volumes.sh
+++ b/scripts/configure-volumes.sh
@@ -52,6 +52,25 @@ configure_local_docker_volumes() {
 }
 
 choose_volumes () {
+  set +u
+  echo "ZEALOT_FORCE_VOLUME=${ZEALOT_FORCE_VOLUME}"
+
+  if [ -n "$ZEALOT_FORCE_VOLUME" ]; then
+    case "$ZEALOT_FORCE_VOLUME" in
+      "docker" )
+        create_docker_volumes;;
+      "local" )
+        configure_local_docker_volumes;;
+      * )
+        echo "Invalid ZEALOT_FORCE_VOLUME value, Quitting"
+        exit
+        ;;
+    esac
+    set -u
+    return
+  fi
+  set -u
+
   printf "Which way do you choose to storage zealot data?\n\
   Use Docker [V]olumes (default)\n\
   Use [L]ocal file system\n"

--- a/scripts/configure-volumes.sh
+++ b/scripts/configure-volumes.sh
@@ -92,7 +92,12 @@ choose_volumes () {
   fi
 }
 
-VOLUMES_EXISTS=$(grep -cE "^(\s+)zealot\-(\w+):" $DOCKER_COMPOSE_FILE || echo 0)
+if [ -f "$DOCKER_COMPOSE_FILE" ]; then
+  VOLUMES_EXISTS=$(grep -cE "^(\s+)zealot\-(\w+):" $DOCKER_COMPOSE_FILE || true)
+else
+  VOLUMES_EXISTS=0
+fi
+echo "VOLUMES_EXISTS=$VOLUMES_EXISTS"
 if [[ "$VOLUMES_EXISTS" -gt 3 ]]; then
   echo "Volumes already exists, skipped"
 else

--- a/scripts/generate-compose-file.sh
+++ b/scripts/generate-compose-file.sh
@@ -1,5 +1,7 @@
 echo "${_group}Generating docker-compose.file ..."
 
+ZEALOT_NO_SSL_PORT=${ZEALOT_NO_SSL_PORT:-"80"}
+
 if [ -f "$DOCKER_COMPOSE_FILE" ]; then
   echo "File already exists, skipped"
 else
@@ -14,7 +16,7 @@ else
 
   if [ "$ZEALOT_USE_SSL" == "false" ]; then
     echo "    ports:"  >> $DOCKER_COMPOSE_FILE
-    echo '      - "80:80"' >> $DOCKER_COMPOSE_FILE
+    echo '      - "'"${ZEALOT_NO_SSL_PORT}"':80"' >> $DOCKER_COMPOSE_FILE
   else
     cat $TEMPLATE_DOCKER_COMPOSE_PATH/cert.yml >> $DOCKER_COMPOSE_FILE
   fi

--- a/scripts/generate-domain.sh
+++ b/scripts/generate-domain.sh
@@ -14,9 +14,9 @@ fi
 if [ -z "$DOMAIN" ]; then
   echo "Read ZEALOT_DOMAIN failed, skipped"
 else
-  sed -i -e 's/^.*ZEALOT_DOMAIN=.*$/ZEALOT_DOMAIN='"$DOMAIN"'/' $ENV_FILE
-  clean_sed_temp_file $ENV_FILE
   if [ "$DOMAIN_FROM_USER" == "1" ]; then
+    sed -i -e 's/^.*ZEALOT_DOMAIN=.*$/ZEALOT_DOMAIN='"$DOMAIN"'/' $ENV_FILE
+    clean_sed_temp_file $ENV_FILE
     echo "Domain written to .env"
   fi
 fi


### PR DESCRIPTION
Add environment variable options `ZEALOT_FORCE_SSL`, `ZEALOT_FORCE_VOLUME`, and `ZEALOT_NO_SSL_PORT` which can be set in `env.sh`.

These values force `./deploy` to not query for user input and hard set the values in `.env`. `ZEALOT_FORCE_SSL` changes the default external port from 80 to a user selected value.

Fix error running `./deploy` when `ZEALOT_DOMAIN` is set
Fix error running configure-volumes.sh